### PR TITLE
Commited in migration

### DIFF
--- a/migrations/1698765432345_create-todos-table.js
+++ b/migrations/1698765432345_create-todos-table.js
@@ -3,7 +3,6 @@ exports.up = (pgm) => {
     id: 'id',
     title: { type: 'varchar(255)', notNull: true },
     completed: { type: 'boolean', notNull: true, default: false },
-    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') }, // ✅ Added column
   });
 };
 

--- a/migrations/1698765432345_create-todos-table.js
+++ b/migrations/1698765432345_create-todos-table.js
@@ -3,6 +3,7 @@ exports.up = (pgm) => {
     id: 'id',
     title: { type: 'varchar(255)', notNull: true },
     completed: { type: 'boolean', notNull: true, default: false },
+    created_at: { type: 'timestamp', notNull: true, default: pgm.func('current_timestamp') }, // ✅ Added column
   });
 };
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -79,7 +79,7 @@
         <h1>Todo List</h1>
         
         <form class="todo-form" action="/todos" method="POST">
-            <input type="text" name="title" placeholder="Enter a new todo" required>
+            <input type="text" name="title" placeholder="Enter a new todo " required>
             <button type="submit">Add Todo</button>
         </form>
 


### PR DESCRIPTION
This PR fixes an issue where the created_at column was missing from the todos table, causing errors when querying for todos. The migration file has been updated to include a created_at column with a default value of the current timestamp.